### PR TITLE
Fix modal layout centering

### DIFF
--- a/ind
+++ b/ind
@@ -157,7 +157,7 @@
       left: 0; top: 0; right: 0; bottom: 0;
       background: rgba(44,26,73,0.31);
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       justify-content: center;
     }
     .ops-modal, .modal-content, #chatbot-container {
@@ -170,10 +170,8 @@
       border-radius: 2rem;
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
       padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-      position: absolute;
-      left: 50%;
-      top: 12vh;
-      transform: translate(-50%, 0);
+      max-height: 93vh;
+      overflow-y: auto;
       transition: box-shadow .17s;
       cursor: default;
       z-index: 2222;
@@ -317,9 +315,6 @@
       max-width: 490px;
       width: 96vw;
       height: 510px;
-      left: 50%; top: 12vh;
-      transform: translate(-50%, 0);
-      overflow: hidden;
       display: flex;
       flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- center the modal backdrop content
- let flexbox center the modal container
- stop absolutely positioning the chatbot container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688347d30a98832bb1fdf3c8445a669a